### PR TITLE
Compatibility with retryable version 2

### DIFF
--- a/lib/niftp.rb
+++ b/lib/niftp.rb
@@ -14,7 +14,7 @@ module NiFTP
   def ftp(host, options = {}, &block)
     options = default_options.merge(options)
     raise "The :tries option must be > 0." if options[:tries] < 1
-    retryable(retryable_options(options)) do
+    Retryable.retryable(retryable_options(options)) do
       ftp = instantiate_ftp_per_options(options)
       begin
         login_with_timeout(ftp, host, options)

--- a/lib/niftp/version.rb
+++ b/lib/niftp/version.rb
@@ -1,3 +1,3 @@
 module NiFTP
-  VERSION = "2.0.1"
+  VERSION = "2.1.0"
 end

--- a/niftp.gemspec
+++ b/niftp.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.add_dependency "ftpfxp",                     ">= 0.0.4"
-  s.add_dependency "retryable",                  ">= 1.3"
+  s.add_dependency "retryable",                  ">= 2.0"
   s.add_dependency "i18n",                       ">= 0.5"
   s.add_development_dependency "minitest",       "~> 4.7"
   s.add_development_dependency "guard",          "~> 1.8.3"

--- a/test/niftp_test.rb
+++ b/test/niftp_test.rb
@@ -64,7 +64,7 @@ module NiFTP
 
       it "must use the retryable defauls when they're not explicitly set" do
         Net::FTP.stubs(:new => ftp)
-        object.expects(:retryable).with(:tries => 2, :sleep => 1,
+        Retryable.expects(:retryable).with(:tries => 2, :sleep => 1,
           :on => StandardError, :matching => /.*/)
         object.ftp(host) { }
       end


### PR DESCRIPTION
The retryable gem has now made its 'retryable' method a class method from Retryable. These changes ensure NiFTP is compatible with that change. Tests also updated, and I've changed the version number.
