### PR TITLE
Update FTPS to work with Ruby 2+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - "1.9.3"
   - "2.0.0"
   - "2.1.0"
   - "2.2.0"
+  - "2.2.3"
   - jruby-19mode # JRuby in 1.9 mode

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,0 @@
-group :ruby do
-  guard :minitest, all_on_start: false do
-    watch(%r{^test/.+_test\.rb$})
-    watch('test/test_helper.rb') { "test" }
-    watch(%r{^lib/(.+)\.rb$})    { |m| "test/#{m[1]}_test.rb" }
-  end
-end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,7 @@
+group :ruby do
+  guard :minitest, all_on_start: false do
+    watch(%r{^test/.+_test\.rb$})
+    watch('test/test_helper.rb') { "test" }
+    watch(%r{^lib/(.+)\.rb$})    { |m| "test/#{m[1]}_test.rb" }
+ end
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,0 @@
-group :ruby do
-  guard :minitest, all_on_start: false do
-    watch(%r{^test/.+_test\.rb$})
-    watch('test/test_helper.rb') { "test" }
-    watch(%r{^lib/(.+)\.rb$})    { |m| "test/#{m[1]}_test.rb" }
- end
-end

--- a/README.md
+++ b/README.md
@@ -20,15 +20,24 @@ forced timeouts. FTP Secure (FTPS) is also supported.
 
     # A more concrete example:
 
-    # Mixin the +NiFTP+ module, which provides the +ftp+ method.
+    # Mixin the +NiFTP+ module, which provides the +ftps+ method.
     require 'niftp'
     class SomeObject
       include NiFTP
 
+      def ftps_options
+        {
+          username: "",
+          password: "",
+          ftps: true,
+          ssl_context_params: {
+            verify_mode: OpenSSL::SSL::VERIFY_NONE
+          }
+        }
+      end
+
       def ftp_stuff
-        # get a file from an FTP Secure (FTPS) server
-        ftp("ftp.secure.com", { username: "some_user", password: "FTP_FTL",
-                                ftps: true }) do |client|
+        ftp("ftp.appareldownload.com", ftps_options) do |client|
           files = client.list('n*')
           # ...
           file = client.getbinaryfile('nif.rb-0.91.gz', 'nif.gz', 1024)
@@ -42,7 +51,6 @@ forced timeouts. FTP Secure (FTPS) is also supported.
 * **username**: The user name, if required by the host (default: "").
 * **password**: The password, if required by the host (default: "").
 * **port**: The port for the host (default: 21).
-* **ftps**: Set to true if connecting to a FTP Secure server (default: false).
 * **tries**: The number of times to try the given FTP commands upon any
   exception, before raising the exception (Default: 2, meaning it will *retry
   once* upon any exception).
@@ -57,6 +65,9 @@ forced timeouts. FTP Secure (FTPS) is also supported.
   (default: 30). Use 0 to disable the authentication timeout.
 * **passive**: Set to false to prevent a connection in passive mode (default:
   true).
+* **ftps**: Set to true if connecting to a FTP Secure server (default: false).
+* **ftps_mode**: Set to one of the following: DoubleBagFTPS::EXPLICIT or DoubleBagFTPS::IMPLICIT (default: DoubleBagFTPS::IMPLICIT).
+* **ssl_context_params**: See the [DoubleBagFTPS](https://github.com/bnix/double-bag-ftps) for options. (default: { }).
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ forced timeouts. FTP Secure (FTPS) is also supported.
 
     # A more concrete example:
 
-    # Mixin the +NiFTP+ module, which provides the +ftps+ method.
+    # Mixin the +NiFTP+ module, which provides the +ftp+ method.
     require 'niftp'
     class SomeObject
       include NiFTP
@@ -66,7 +66,7 @@ forced timeouts. FTP Secure (FTPS) is also supported.
 * **passive**: Set to false to prevent a connection in passive mode (default:
   true).
 * **ftps**: Set to true if connecting to a FTP Secure server (default: false).
-* **ftps_mode**: Set to one of the following: DoubleBagFTPS::EXPLICIT or DoubleBagFTPS::IMPLICIT (default: DoubleBagFTPS::IMPLICIT).
+* **ftps_mode**: Set to one of the following: `DoubleBagFTPS::EXPLICIT` or `DoubleBagFTPS::IMPLICIT` (default: `DoubleBagFTPS::IMPLICIT`).
 * **ssl_context_params**: See the [DoubleBagFTPS](https://github.com/bnix/double-bag-ftps) for options. (default: { }).
 
 ## Caveats

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-NiFTP, a Ruby gem, makes Ruby's decidedly un-nifty Net::FTP library easier to
+## NiFTP
+Only supports Ruby 2.0.0+
+A Ruby gem, makes Ruby's decidedly un-nifty Net::FTP library easier to
 use. It abstracts away the FTP plumbing, such as establishing and closing
 connections. Options include retrying your commands on flakey FTP servers, and
 forced timeouts. FTP Secure (FTPS) is also supported.

--- a/lib/niftp.rb
+++ b/lib/niftp.rb
@@ -1,5 +1,5 @@
 require "net/ftp"
-require "ftpfxp"
+require "double_bag_ftps"
 require "retryable"
 require "timeout"
 
@@ -35,8 +35,20 @@ module NiFTP
   end
 
   def instantiate_ftp_per_options(options)
-    (options[:ftps] ? Net::FTPFXPTLS.new : Net::FTP.new).tap do |ftp|
-      ftp.passive = options[:passive]
+    (options[:ftps] ? DoubleBagFTPS.new : Net::FTP.new).tap do |obj|
+      if options[:ftps]
+        if options[:ftps_mode]
+          obj.ftps_mode = options[:ftps_mode]
+        end
+
+        if options[:ssl_context_params]
+          obj.ssl_context = DoubleBagFTPS.create_ssl_context(
+            options[:ssl_context_params]
+          )
+        end
+      end
+
+      obj.passive = options[:passive]
     end
   end
 

--- a/niftp.gemspec
+++ b/niftp.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |s|
   s.add_dependency "retryable",                  ">= 2.0"
   s.add_dependency "i18n",                       ">= 0.5"
   s.add_development_dependency "minitest",       "~> 4.7"
+  s.add_development_dependency "guard",          "~> 1.8.3"
+  s.add_development_dependency "guard-minitest", "~> 1.0.1"
   s.add_development_dependency "mocha",          "~> 0.14"
   s.add_development_dependency "rake"
 end

--- a/niftp.gemspec
+++ b/niftp.gemspec
@@ -32,8 +32,6 @@ Gem::Specification.new do |s|
   s.add_dependency "retryable",                  ">= 2.0"
   s.add_dependency "i18n",                       ">= 0.5"
   s.add_development_dependency "minitest",       "~> 4.7"
-  s.add_development_dependency "guard",          "~> 1.8.3"
-  s.add_development_dependency "guard-minitest", "~> 1.0.1"
   s.add_development_dependency "mocha",          "~> 0.14"
   s.add_development_dependency "rake"
 end

--- a/niftp.gemspec
+++ b/niftp.gemspec
@@ -28,12 +28,10 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md"] + Dir.glob("doc/*")
 
   # Dependencies
-  s.add_dependency "ftpfxp",                     ">= 0.0.4"
+  s.add_dependency "double-bag-ftps",            ">= 0.1.3"
   s.add_dependency "retryable",                  ">= 2.0"
   s.add_dependency "i18n",                       ">= 0.5"
   s.add_development_dependency "minitest",       "~> 4.7"
-  s.add_development_dependency "guard",          "~> 1.8.3"
-  s.add_development_dependency "guard-minitest", "~> 1.0.1"
   s.add_development_dependency "mocha",          "~> 0.14"
   s.add_development_dependency "rake"
 end

--- a/test/niftp_test.rb
+++ b/test/niftp_test.rb
@@ -98,8 +98,8 @@ module NiFTP
         object.ftp(host, { :timeout => 1 })
       end
 
-      it "must use the FTPFXP (FTPS) library when instructed" do
-        Net::FTPFXPTLS.expects(:new).once.returns(ftp)
+      it "must use the DoubleBagFTPS library when instructed" do
+        DoubleBagFTPS.expects(:new).once.returns(ftp)
         object.ftp(host, { :ftps => true })
       end
     end


### PR DESCRIPTION
Upgrading FTPFXP with DoubleBagFTPS. FTPFXP doesn't work with Ruby 2+.